### PR TITLE
Tasks timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .python-version
+.vscode

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 from fastapi import FastAPI
 from fastapi.responses import PlainTextResponse
 from fastapi.staticfiles import StaticFiles
+from dateutil.parser import isoparse
 import uvicorn
 import docker
 import time
@@ -28,6 +29,8 @@ env = Environment(
     autoescape=select_autoescape(['j2'])
 )
 template = env.get_template(exporter_mode + '_metrics.j2')
+
+last_tasks_cache = {}
 
 async def scrape_containers_info():
     while True:
@@ -73,16 +76,18 @@ async def get_containers():
         cli.close()
     return(t)
 
-async def get_tasks(service):
+async def update_tasks(service):
     t = []
     for task in service.tasks():
-        if task['DesiredState'] == "running":
-            t.append({
-                "id": task['ID'],
-                "desired_state": task['DesiredState'],
-                "status": task['Status']['State']
-            })
-    return(t)
+        t.append({
+            "id": task['ID'],
+            "desired_state": task['DesiredState'],
+            "status": task['Status']['State'],
+            "status_timestamp": isoparse(task['Status']['Timestamp']).timestamp()
+        })
+    if len(t) != 0:
+        global last_tasks_cache
+        last_tasks_cache[service.name] = t 
 
 async def get_services():
     cli = await get_docker_client()
@@ -93,11 +98,13 @@ async def get_services():
             if 'Replicated' in service_inspect["Spec"]["Mode"]:
                 replicas = service_inspect["Spec"]["Mode"]["Replicated"]["Replicas"]
             else: replicas = -1
+            await update_tasks(service=service)
+            tasks = last_tasks_cache.get(service.name, [])
             s.append({
                 "name": service.name,
                 "image": service_inspect['Spec']['TaskTemplate']['ContainerSpec']['Image'],
                 "replicas": replicas,
-                "tasks": await get_tasks(service),
+                "tasks": tasks,
                 "time": int(time.time())
             })
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ docker==7.1.0
 fastapi==0.87.0
 Jinja2==3.1.5
 uvicorn==0.34.0
+python-dateutil==2.8.2

--- a/templates/swarm_metrics.j2
+++ b/templates/swarm_metrics.j2
@@ -9,11 +9,18 @@ service_last_seen{service_name="{{ service.name }}",image="{{ service.image }}"}
 service_replicas{service_name="{{ service.name }}",image="{{ service.image }}"} {{ service.replicas }}
 {%-endfor%}
 {%for status in statuses-%}
-# HELP task_status_{{ status }} The status of task equals "{{ status }}"
+# HELP task_status_{{ status }} The last status of task equals "{{ status }}"
 # TYPE task_status_{{ status }} gauge
 {%-for service in services%}
 {%-for task in service.tasks%}
 task_status_{{ status }}{service_name="{{ service.name }}",task_id="{{ task.id }}",image="{{ service.image }}"} {%if task.status == status%}1{%else%}0{%endif%}
+{%-endfor%}
+{%-endfor%}
+# HELP task_status_{{ status }}_timestamp The last timestamp of task equals "{{ status }}"
+# TYPE task_status_{{ status }}_timestamp unix timestamp
+{%-for service in services%}
+{%-for task in service.tasks%}
+task_status_{{ status }}_timestamp{service_name="{{ service.name }}",task_id="{{ task.id }}",image="{{ service.image }}"} {{ task.status_timestamp }}
 {%-endfor%}
 {%-endfor%}
 {%endfor%}


### PR DESCRIPTION
Нам необходимо запоминать состояние последних тасок в сервисе. Актуальная версия экспортера теряет их и не выводит в /metrics, если у сервиса их нет. Для этого мной был написан небольшой cache-словарь, который их сохраняет и /metrics страница рендерится на его основе.